### PR TITLE
feat: user profile CRUD

### DIFF
--- a/.adonisrc.json
+++ b/.adonisrc.json
@@ -16,7 +16,8 @@
   "preloads": [
     "./start/routes",
     "./start/kernel",
-    "./start/events"
+    "./start/events",
+    "./start/custom-validators"
   ],
   "providers": [
     "./providers/AppProvider",

--- a/app/Controllers/Http/ProfilesController.ts
+++ b/app/Controllers/Http/ProfilesController.ts
@@ -1,16 +1,16 @@
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
-import { DateTime } from 'luxon'
-import Profile from 'App/Models/Profile'
 import CreateProfileValidator from 'App/Validators/CreateProfileValidator'
 import UpdateProfileValidator from 'App/Validators/UpdateProfileValidator'
 import DeleteProfileValidator from 'App/Validators/DeleteProfileValidator'
+import ProfileService from 'App/Services/ProfileService'
+
+const profileService = new ProfileService()
 
 export default class ProfilesController {
 
   public async show({ auth, response }: HttpContextContract) {
     const user = auth.user!
-
-    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
+    const profile = await profileService.getProfile(user.id)
 
     return response.ok({
       name: profile.name,
@@ -23,8 +23,7 @@ export default class ProfilesController {
   public async create({ auth, request, response }: HttpContextContract) {
     const user = auth.user!
 
-    const existingProfile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').first()
-    if (existingProfile) {
+    if (await profileService.profileExists(user.id)) {
       return response.conflict({
         message: 'Profile already exists. Use PUT /user/profile to update it.',
       })
@@ -32,8 +31,7 @@ export default class ProfilesController {
 
     const payload = await request.validate(CreateProfileValidator)
 
-    const profile = await Profile.create({
-      userId: user.id,
+    const profile = await profileService.createProfile(user.id, {
       name: payload.name,
       mobile: payload.mobile,
       gender: payload.gender,
@@ -48,19 +46,14 @@ export default class ProfilesController {
 
   public async update({ auth, request, response }: HttpContextContract) {
     const user = auth.user!
-
-    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
-
     const payload = await request.validate(UpdateProfileValidator)
 
-    profile.merge({
+    const profile = await profileService.updateProfile(user.id, {
       name: payload.name,
       mobile: payload.mobile,
       gender: payload.gender,
       dateOfBirth: payload.date_of_birth.toISODate()!,
     })
-
-    await profile.save()
 
     return response.ok({
       message: 'Profile updated successfully',
@@ -70,22 +63,15 @@ export default class ProfilesController {
 
   public async destroy({ auth, request, response }: HttpContextContract) {
     const user = auth.user!
-
     const payload = await request.validate(DeleteProfileValidator)
 
-    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
+    const deleted = await profileService.deleteProfile(user.id, payload.mobile, user)
 
-    if (profile.mobile !== payload.mobile) {
+    if (!deleted) {
       return response.badRequest({
         message: 'Mobile number does not match. Account not deleted.',
       })
     }
-
-    profile.deletedAt = DateTime.now()
-    await profile.save()
-
-    user.deletedAt = DateTime.now()
-    await user.save()
 
     return response.ok({
       message: 'Account and profile deleted successfully',

--- a/app/Controllers/Http/ProfilesController.ts
+++ b/app/Controllers/Http/ProfilesController.ts
@@ -1,67 +1,90 @@
-import { HttpContextContract } from "@ioc:Adonis/Core/HttpContext";
-import Database from "@ioc:Adonis/Lucid/Database";
-import Profile from "App/Models/Profile";
-import Role from "App/Models/Role";
-import User from "App/Models/User";
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import Profile from 'App/Models/Profile'
+import CreateProfileValidator from 'App/Validators/CreateProfileValidator'
+import UpdateProfileValidator from 'App/Validators/UpdateProfileValidator'
+import DeleteProfileValidator from 'App/Validators/DeleteProfileValidator'
 
 export default class ProfilesController {
 
-    public async index({ request, auth}: HttpContextContract)
-    {
-        console.log('abcbccccc')
-        const page = request.input('page', 1)
-        const users = await User.query().preload('profile').paginate(page, 3)
-        return users
+  public async show({ auth, response }: HttpContextContract) {
+    const user = auth.user!
+
+    const profile = await Profile.findByOrFail('user_id', user.id)
+
+    return response.ok({
+      name: profile.name,
+      email: user.email,
+      gender: profile.gender,
+      date_of_birth: profile.dateOfBirth,
+    })
+  }
+
+  public async create({ auth, request, response }: HttpContextContract) {
+    const user = auth.user!
+
+    const existingProfile = await Profile.findBy('user_id', user.id)
+    if (existingProfile) {
+      return response.conflict({
+        message: 'Profile already exists. Use PUT /user/profile to update it.',
+      })
     }
-    
-    public async show({ request, auth, params}: HttpContextContract)
-    {
-        try {
-            console.log(params, 'abbcccc')
-            const user = await auth.authenticate()            
-            await user.load('profile');
-            return user;
-            
-        } catch (error) {
-        	console.log(error)
-        }
+
+    const payload = await request.validate(CreateProfileValidator)
+
+    const profile = await Profile.create({
+      userId: user.id,
+      name: payload.name,
+      mobile: payload.mobile,
+      gender: payload.gender,
+      dateOfBirth: payload.date_of_birth.toISODate()!,
+    })
+
+    return response.created({
+      message: 'Profile created successfully',
+      profile,
+    })
+  }
+
+  public async update({ auth, request, response }: HttpContextContract) {
+    const user = auth.user!
+
+    const profile = await Profile.findByOrFail('user_id', user.id)
+
+    const payload = await request.validate(UpdateProfileValidator)
+
+    profile.merge({
+      name: payload.name,
+      mobile: payload.mobile,
+      gender: payload.gender,
+      dateOfBirth: payload.date_of_birth.toISODate()!,
+    })
+
+    await profile.save()
+
+    return response.ok({
+      message: 'Profile updated successfully',
+      profile,
+    })
+  }
+
+  public async destroy({ auth, request, response }: HttpContextContract) {
+    const user = auth.user!
+
+    const payload = await request.validate(DeleteProfileValidator)
+
+    const profile = await Profile.findByOrFail('user_id', user.id)
+
+    if (profile.mobile !== payload.mobile) {
+      return response.badRequest({
+        message: 'Mobile number does not match. Account not deleted.',
+      })
     }
-    
-    public async update({ auth, request, params}: HttpContextContract)
-    {
-        const profile = await Profile.find(params.id);
-        if (profile) {
-            profile.first_name = request.input('first_name');
-            profile.last_name = request.input('last_name');
-            profile.dob = request.input('dob');
-            profile.role = request.input('role');
-            
-            if (await profile.save()) {
-            	return profile
-        	}
-        	return;
-        }
-        return;
-    }
-    
-    public async store({ auth, request, response}: HttpContextContract)
-    {
-        const user = await auth.authenticate();
-        console.log(user)
-        const profile = new Profile();
-        profile.user_id = user.$attributes.id
-        profile.first_name = request.input('first_name');
-        profile.last_name = request.input('last_name');
-        profile.dob = request.input('dob');
-        profile.role = request.input('role');
-        await profile.save()
-        return profile
-    }
-    
-    public async destroy({response, auth, request, params}: HttpContextContract)
-    {
-        const user = await auth.authenticate();
-        const profile = await Profile.query().where('id', request.input('id')).delete();
-        return response.json({message:"Deleted successfully"})
-    }
+
+    await profile.delete()
+    await user.delete()
+
+    return response.ok({
+      message: 'Account and profile deleted successfully',
+    })
+  }
 }

--- a/app/Controllers/Http/ProfilesController.ts
+++ b/app/Controllers/Http/ProfilesController.ts
@@ -1,4 +1,5 @@
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { DateTime } from 'luxon'
 import Profile from 'App/Models/Profile'
 import CreateProfileValidator from 'App/Validators/CreateProfileValidator'
 import UpdateProfileValidator from 'App/Validators/UpdateProfileValidator'
@@ -9,7 +10,7 @@ export default class ProfilesController {
   public async show({ auth, response }: HttpContextContract) {
     const user = auth.user!
 
-    const profile = await Profile.findByOrFail('user_id', user.id)
+    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
 
     return response.ok({
       name: profile.name,
@@ -22,7 +23,7 @@ export default class ProfilesController {
   public async create({ auth, request, response }: HttpContextContract) {
     const user = auth.user!
 
-    const existingProfile = await Profile.findBy('user_id', user.id)
+    const existingProfile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').first()
     if (existingProfile) {
       return response.conflict({
         message: 'Profile already exists. Use PUT /user/profile to update it.',
@@ -48,7 +49,7 @@ export default class ProfilesController {
   public async update({ auth, request, response }: HttpContextContract) {
     const user = auth.user!
 
-    const profile = await Profile.findByOrFail('user_id', user.id)
+    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
 
     const payload = await request.validate(UpdateProfileValidator)
 
@@ -72,7 +73,7 @@ export default class ProfilesController {
 
     const payload = await request.validate(DeleteProfileValidator)
 
-    const profile = await Profile.findByOrFail('user_id', user.id)
+    const profile = await Profile.query().where('user_id', user.id).whereNull('deleted_at').firstOrFail()
 
     if (profile.mobile !== payload.mobile) {
       return response.badRequest({
@@ -80,8 +81,11 @@ export default class ProfilesController {
       })
     }
 
-    await profile.delete()
-    await user.delete()
+    profile.deletedAt = DateTime.now()
+    await profile.save()
+
+    user.deletedAt = DateTime.now()
+    await user.save()
 
     return response.ok({
       message: 'Account and profile deleted successfully',

--- a/app/Models/Profile.ts
+++ b/app/Models/Profile.ts
@@ -29,6 +29,9 @@ export default class Profile extends BaseModel {
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   public updatedAt!: DateTime
 
+  @column.dateTime()
+  public deletedAt: DateTime | null = null
+
   @belongsTo(() => User)
   public user!: BelongsTo<typeof User>
 }

--- a/app/Models/Profile.ts
+++ b/app/Models/Profile.ts
@@ -1,36 +1,34 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, hasOne, HasOne, belongsTo, BelongsTo } from '@ioc:Adonis/Lucid/Orm'
-import User from './User'
+import { column, BaseModel, belongsTo } from '@ioc:Adonis/Lucid/Orm'
+import { BelongsTo } from '@ioc:Adonis/Lucid/Orm'
+import User from 'App/Models/User'
 
 export default class Profile extends BaseModel {
 
-  @column()
-  public user_id: number
-
-  @belongsTo(() => User)
-  public user: BelongsTo<typeof User>
-
   @column({ isPrimary: true })
-  public id: number
+  public id!: number
 
   @column()
-  public first_name: string
+  public userId!: number
 
   @column()
-  public last_name: string
+  public name!: string
 
   @column()
-  public dob: string
+  public mobile!: string
 
   @column()
-  public role: string
+  public gender!: 'MALE' | 'FEMALE'
 
-  // @column()
-  // public done: boolean
+  @column()
+  public dateOfBirth!: string
 
   @column.dateTime({ autoCreate: true })
-  public createdAt: DateTime
+  public createdAt!: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  public updatedAt: DateTime
+  public updatedAt!: DateTime
+
+  @belongsTo(() => User)
+  public user!: BelongsTo<typeof User>
 }

--- a/app/Models/User.ts
+++ b/app/Models/User.ts
@@ -24,6 +24,9 @@ export default class User extends BaseModel {
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   public updatedAt!: DateTime
 
+  @column.dateTime()
+  public deletedAt: DateTime | null = null
+
   @beforeSave()
   public static async hashPassword(user: User) {
     if (user.$dirty.password) {

--- a/app/Models/User.ts
+++ b/app/Models/User.ts
@@ -1,48 +1,36 @@
 import { DateTime } from 'luxon'
 import Hash from '@ioc:Adonis/Core/Hash'
-import { column, beforeSave, BaseModel, hasMany, HasMany, hasOne, HasOne, manyToMany, ManyToMany } from '@ioc:Adonis/Lucid/Orm'
-import Profile from './Profile'
-import Role from './Role'
+import { column, beforeSave, BaseModel, hasOne } from '@ioc:Adonis/Lucid/Orm'
+import { HasOne } from '@ioc:Adonis/Lucid/Orm'
+import Profile from 'App/Models/Profile'
 
 export default class User extends BaseModel {
 
-  @column()
-  public role_id: number
-
-  @manyToMany(() => Role)
-  public role: ManyToMany<typeof Role>
-
-  @hasOne(() => Profile, {
-  foreignKey: 'user_id'
-  })
-  public profile: HasOne<typeof Profile>
-
   @column({ isPrimary: true })
-  public id: number
+  public id!: number
 
   @column()
-  public username: string;
-
-  @column()
-  public email: string
+  public email!: string
 
   @column({ serializeAs: null })
-  public password: string
+  public password!: string
 
   @column()
   public rememberMeToken?: string
 
   @column.dateTime({ autoCreate: true })
-  public createdAt: DateTime
+  public createdAt!: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  public updatedAt: DateTime
-  hasOne: any
+  public updatedAt!: DateTime
 
   @beforeSave()
-  public static async hashPassword (user: User) {
+  public static async hashPassword(user: User) {
     if (user.$dirty.password) {
       user.password = await Hash.make(user.password)
     }
   }
+
+  @hasOne(() => Profile)
+  public profile!: HasOne<typeof Profile>
 }

--- a/app/Rules/UniqueMobile.ts
+++ b/app/Rules/UniqueMobile.ts
@@ -1,0 +1,16 @@
+import Database from '@ioc:Adonis/Lucid/Database'
+import { ValidationRuntimeOptions } from '@ioc:Adonis/Core/Validator'
+
+export async function uniqueMobile(value: unknown, _: unknown, options: ValidationRuntimeOptions) {
+  if (typeof value !== 'string') return
+
+  const row = await Database.from('profiles').where('mobile', value).first()
+  if (row) {
+    options.errorReporter.report(
+      options.pointer,
+      'uniqueMobile',
+      'Mobile number is already in use',
+      options.arrayExpressionPointer
+    )
+  }
+}

--- a/app/Services/ProfileService.ts
+++ b/app/Services/ProfileService.ts
@@ -1,0 +1,52 @@
+import { DateTime } from 'luxon'
+import Profile from 'App/Models/Profile'
+import User from 'App/Models/User'
+
+export default class ProfileService {
+
+  public async getProfile(userId: number) {
+    return Profile.query().where('user_id', userId).whereNull('deleted_at').firstOrFail()
+  }
+
+  public async profileExists(userId: number) {
+    const profile = await Profile.query().where('user_id', userId).whereNull('deleted_at').first()
+    return !!profile
+  }
+
+  public async createProfile(userId: number, data: {
+    name: string
+    mobile: string
+    gender: 'MALE' | 'FEMALE'
+    dateOfBirth: string
+  }) {
+    return Profile.create({ userId, ...data })
+  }
+
+  public async updateProfile(userId: number, data: {
+    name: string
+    mobile: string
+    gender: 'MALE' | 'FEMALE'
+    dateOfBirth: string
+  }) {
+    const profile = await this.getProfile(userId)
+    profile.merge(data)
+    await profile.save()
+    return profile
+  }
+
+  public async deleteProfile(userId: number, mobile: string, user: User) {
+    const profile = await this.getProfile(userId)
+
+    if (profile.mobile !== mobile) {
+      return false
+    }
+
+    profile.deletedAt = DateTime.now()
+    await profile.save()
+
+    user.deletedAt = DateTime.now()
+    await user.save()
+
+    return true
+  }
+}

--- a/app/Validators/CreateProfileValidator.ts
+++ b/app/Validators/CreateProfileValidator.ts
@@ -5,6 +5,11 @@ import { DateTime } from 'luxon'
 export default class CreateProfileValidator {
   constructor(protected ctx: HttpContextContract) {}
 
+  public refs = schema.refs({
+    minDob: DateTime.now().minus({ years: 18 }),
+    maxDob: DateTime.now().minus({ years: 100 }),
+  })
+
   public schema = schema.create({
     name: schema.string({ trim: true }, [
       rules.minLength(3),
@@ -12,11 +17,12 @@ export default class CreateProfileValidator {
     ]),
     mobile: schema.string({ trim: true }, [
       rules.regex(/^[0-9]{10}$/),
+      rules.uniqueMobile(),
     ]),
     gender: schema.enum(['MALE', 'FEMALE'] as const),
     date_of_birth: schema.date({ format: 'yyyy-MM-dd' }, [
-      rules.before(DateTime.now().minus({ years: 18 })),
-      rules.after(DateTime.now().minus({ years: 100 })),
+      rules.before(this.refs.minDob),
+      rules.after(this.refs.maxDob),
     ]),
   })
 

--- a/app/Validators/CreateProfileValidator.ts
+++ b/app/Validators/CreateProfileValidator.ts
@@ -1,0 +1,30 @@
+import { schema, rules, CustomMessages } from '@ioc:Adonis/Core/Validator'
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+
+export default class CreateProfileValidator {
+  constructor(protected ctx: HttpContextContract) {}
+
+  public schema = schema.create({
+    name: schema.string({ trim: true }, [
+      rules.minLength(3),
+      rules.maxLength(30),
+    ]),
+    mobile: schema.string({ trim: true }, [
+      rules.regex(/^[0-9]{10}$/),
+    ]),
+    gender: schema.enum(['MALE', 'FEMALE'] as const),
+    date_of_birth: schema.date({ format: 'yyyy-MM-dd' }),
+  })
+
+  public messages: CustomMessages = {
+    'name.required'          : 'Name is required',
+    'name.minLength'         : 'Name must be at least 3 characters',
+    'name.maxLength'         : 'Name cannot exceed 30 characters',
+    'mobile.required'        : 'Mobile number is required',
+    'mobile.regex'           : 'Mobile number must be exactly 10 digits',
+    'gender.required'        : 'Gender is required',
+    'gender.enum'            : 'Gender must be either MALE or FEMALE',
+    'date_of_birth.required' : 'Date of birth is required',
+    'date_of_birth.date'     : 'Date of birth must be a valid date in YYYY-MM-DD format',
+  }
+}

--- a/app/Validators/CreateProfileValidator.ts
+++ b/app/Validators/CreateProfileValidator.ts
@@ -1,5 +1,6 @@
 import { schema, rules, CustomMessages } from '@ioc:Adonis/Core/Validator'
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { DateTime } from 'luxon'
 
 export default class CreateProfileValidator {
   constructor(protected ctx: HttpContextContract) {}
@@ -13,7 +14,10 @@ export default class CreateProfileValidator {
       rules.regex(/^[0-9]{10}$/),
     ]),
     gender: schema.enum(['MALE', 'FEMALE'] as const),
-    date_of_birth: schema.date({ format: 'yyyy-MM-dd' }),
+    date_of_birth: schema.date({ format: 'yyyy-MM-dd' }, [
+      rules.before(DateTime.now().minus({ years: 18 })),
+      rules.after(DateTime.now().minus({ years: 100 })),
+    ]),
   })
 
   public messages: CustomMessages = {
@@ -26,5 +30,7 @@ export default class CreateProfileValidator {
     'gender.enum'            : 'Gender must be either MALE or FEMALE',
     'date_of_birth.required' : 'Date of birth is required',
     'date_of_birth.date'     : 'Date of birth must be a valid date in YYYY-MM-DD format',
+    'date_of_birth.before'   : 'You must be at least 18 years old',
+    'date_of_birth.after'    : 'Age cannot exceed 100 years',
   }
 }

--- a/app/Validators/DeleteProfileValidator.ts
+++ b/app/Validators/DeleteProfileValidator.ts
@@ -1,0 +1,17 @@
+import { schema, rules, CustomMessages } from '@ioc:Adonis/Core/Validator'
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+
+export default class DeleteProfileValidator {
+  constructor(protected ctx: HttpContextContract) {}
+
+  public schema = schema.create({
+    mobile: schema.string({ trim: true }, [
+      rules.regex(/^[0-9]{10}$/),
+    ]),
+  })
+
+  public messages: CustomMessages = {
+    'mobile.required': 'Mobile number is required to delete your account',
+    'mobile.regex'   : 'Mobile number must be exactly 10 digits',
+  }
+}

--- a/app/Validators/UpdateProfileValidator.ts
+++ b/app/Validators/UpdateProfileValidator.ts
@@ -1,0 +1,30 @@
+import { schema, rules, CustomMessages } from '@ioc:Adonis/Core/Validator'
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+
+export default class UpdateProfileValidator {
+  constructor(protected ctx: HttpContextContract) {}
+
+  public schema = schema.create({
+    name: schema.string({ trim: true }, [
+      rules.minLength(3),
+      rules.maxLength(30),
+    ]),
+    mobile: schema.string({ trim: true }, [
+      rules.regex(/^[0-9]{10}$/),
+    ]),
+    gender: schema.enum(['MALE', 'FEMALE'] as const),
+    date_of_birth: schema.date({ format: 'yyyy-MM-dd' }),
+  })
+
+  public messages: CustomMessages = {
+    'name.required'          : 'Name is required',
+    'name.minLength'         : 'Name must be at least 3 characters',
+    'name.maxLength'         : 'Name cannot exceed 30 characters',
+    'mobile.required'        : 'Mobile number is required',
+    'mobile.regex'           : 'Mobile number must be exactly 10 digits',
+    'gender.required'        : 'Gender is required',
+    'gender.enum'            : 'Gender must be either MALE or FEMALE',
+    'date_of_birth.required' : 'Date of birth is required',
+    'date_of_birth.date'     : 'Date of birth must be a valid date in YYYY-MM-DD format',
+  }
+}

--- a/app/Validators/UpdateProfileValidator.ts
+++ b/app/Validators/UpdateProfileValidator.ts
@@ -11,6 +11,11 @@ export default class UpdateProfileValidator {
     ]),
     mobile: schema.string({ trim: true }, [
       rules.regex(/^[0-9]{10}$/),
+      rules.unique({
+        table: 'profiles',
+        column: 'mobile',
+        whereNot: { user_id: this.ctx.auth.user!.id },
+      }),
     ]),
     gender: schema.enum(['MALE', 'FEMALE'] as const),
     date_of_birth: schema.date({ format: 'yyyy-MM-dd' }),
@@ -22,6 +27,7 @@ export default class UpdateProfileValidator {
     'name.maxLength'         : 'Name cannot exceed 30 characters',
     'mobile.required'        : 'Mobile number is required',
     'mobile.regex'           : 'Mobile number must be exactly 10 digits',
+    'mobile.unique'          : 'Mobile number is already in use',
     'gender.required'        : 'Gender is required',
     'gender.enum'            : 'Gender must be either MALE or FEMALE',
     'date_of_birth.required' : 'Date of birth is required',

--- a/config/database.ts
+++ b/config/database.ts
@@ -39,7 +39,7 @@ const databaseConfig: DatabaseConfig = {
         host: Env.get('PG_HOST'),
         port: Env.get('PG_PORT'),
         user: Env.get('PG_USER'),
-        password: Env.get('PG_PASSWORD', ''),
+        password: Env.get('PG_PASSWORD', 'secret'),
         database: Env.get('PG_DB_NAME'),
       },
       migrations: {

--- a/contracts/validator.ts
+++ b/contracts/validator.ts
@@ -1,0 +1,5 @@
+declare module '@ioc:Adonis/Core/Validator' {
+  interface Rules {
+    uniqueMobile(): Rule
+  }
+}

--- a/database/migrations/1780642543622_update_profile_tables.ts
+++ b/database/migrations/1780642543622_update_profile_tables.ts
@@ -1,0 +1,37 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'profiles'
+
+  public async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      // Remove old columns
+      table.dropColumn('first_name')
+      table.dropColumn('last_name')
+      table.dropColumn('dob')
+      table.dropColumn('role')
+
+      // Add new columns
+      table.string('name', 30).notNullable()
+      table.string('mobile', 10).notNullable()
+      table.enum('gender', ['MALE', 'FEMALE']).notNullable()
+      table.date('date_of_birth').notNullable()
+    })
+  }
+
+  public async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      // Remove new columns
+      table.dropColumn('name')
+      table.dropColumn('mobile')
+      table.dropColumn('gender')
+      table.dropColumn('date_of_birth')
+
+      // Restore old columns
+      table.string('first_name', 255).notNullable()
+      table.string('last_name', 255).notNullable()
+      table.string('dob', 255).notNullable()
+      table.string('role', 255).notNullable()
+    })
+  }
+}

--- a/database/migrations/1780913746580_add_soft_delete_to_users_and_profiles.ts
+++ b/database/migrations/1780913746580_add_soft_delete_to_users_and_profiles.ts
@@ -1,0 +1,26 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+import User from 'App/Models/User'
+import Profile from 'App/Models/Profile'
+
+export default class extends BaseSchema {
+
+  public async up() {
+    this.schema.alterTable(User.table, (table) => {
+      table.timestamp('deleted_at', { useTz: true }).nullable()
+    })
+
+    this.schema.alterTable(Profile.table, (table) => {
+      table.timestamp('deleted_at', { useTz: true }).nullable()
+    })
+  }
+
+  public async down() {
+    this.schema.alterTable(User.table, (table) => {
+      table.dropColumn('deleted_at')
+    })
+
+    this.schema.alterTable(Profile.table, (table) => {
+      table.dropColumn('deleted_at')
+    })
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: user_profile_pg
+    environment:
+      POSTGRES_DB: lucid
+      POSTGRES_USER: lucid
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"

--- a/start/custom-validators.ts
+++ b/start/custom-validators.ts
@@ -1,0 +1,4 @@
+import { validator } from '@ioc:Adonis/Core/Validator'
+import { uniqueMobile } from 'App/Rules/UniqueMobile'
+
+validator.rule('uniqueMobile', uniqueMobile)

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -20,25 +20,17 @@
 
 import Route from '@ioc:Adonis/Core/Route'
 
-Route.get('/', async () => {
-  return { hello: 'world' }
-})
+// Auth Routes — Public
+Route.post('/register', 'AuthController.register')
+Route.post('/login',    'AuthController.login')
 
+// Auth Routes — Protected
+Route.post('/logout', 'AuthController.logout').middleware('auth')
+
+// Profile Routes — All Protected
 Route.group(() => {
-
-  Route.post("register", "AuthController.register");
-  Route.post("login", "AuthController.login");
-  
-      Route.group( () => {
-      Route.get("profiles/:id", "ProfilesController.show");
-      Route.put("profiles/update", "ProfilesController.update");
-      Route.post("profiles", "ProfilesController.store");
-      }).middleware("auth:api");
-
-      Route.group(() => {
-        Route.post("profiles/delete", "ProfilesController.destroy"),
-        Route.get("profiles", "ProfilesController.show")
-      }).middleware(["auth", "admin"])
-      
-      
-}).prefix("api");
+  Route.get(    '/profile', 'ProfilesController.show')
+  Route.post(   '/profile', 'ProfilesController.create')
+  Route.put(    '/profile', 'ProfilesController.update')
+  Route.delete( '/profile', 'ProfilesController.destroy')
+}).prefix('/user').middleware('auth')


### PR DESCRIPTION
Added:
- GET    /user/profile - view profile (name, email, gender, date_of_birth only)
- POST   /user/profile - create profile
- PUT    /user/profile - update profile
- DELETE /user/profile - delete profile and user (requires mobile confirmation)

All routes protected by auth middleware.

Validation:
- Name: 3-30 characters
- Mobile: exactly 10 digits only
- Gender: MALE or FEMALE only
- Date of birth: valid date in YYYY-MM-DD format

Also fixed:
- Profile migration updated with correct columns (name, mobile, gender, date_of_birth)
- Profile and User models updated with correct fields